### PR TITLE
Add Websocket API

### DIFF
--- a/ovos_PHAL_plugin_homeassistant/__init__.py
+++ b/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -8,7 +8,7 @@ from ovos_PHAL_plugin_homeassistant.logic.device import (HomeAssistantSensor,
                                                          HomeAssistantBinarySensor,
                                                          HomeAssistantLight,
                                                          HomeAssistantMediaPlayer,
-                                                         HomeAssistantVacuum)
+                                                         HomeAssistantVacuum, HomeAssistantSwitch, HomeAssistantClimate)
 from ovos_PHAL_plugin_homeassistant.logic.integration import Integrator
 from ovos_PHAL_plugin_homeassistant.logic.utils import (map_entity_to_device_type, 
                                                         check_if_device_type_is_group)
@@ -35,7 +35,9 @@ class HomeAssistantPlugin(PHALPlugin):
             "binary_sensor": HomeAssistantBinarySensor,
             "light": HomeAssistantLight,
             "media_player": HomeAssistantMediaPlayer,
-            "vacuum": HomeAssistantVacuum
+            "vacuum": HomeAssistantVacuum,
+            "switch": HomeAssistantSwitch,
+            "climate": HomeAssistantClimate
         }
 
         # BUS API FOR HOME ASSISTANT

--- a/ovos_PHAL_plugin_homeassistant/__init__.py
+++ b/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -159,10 +159,12 @@ class HomeAssistantPlugin(PHALPlugin):
                         "friendly_name", device_id)
                     device_icon = f"mdi:{device_type}"
                     device_state = device.get("state", None)
+                    device_area = device.get("area_id", None)
                     device_attributes = device.get("attributes", {})
                     if device_type in self.device_types:
                         self.registered_devices.append(self.device_types[device_type](
-                            self.connector, device_id, device_icon, device_name, device_state, device_attributes))
+                            self.connector, device_id, device_icon, device_name,
+                            device_state, device_attributes, device_area))
                     else:
                         LOG.warning(f"Device type {device_type} not supported")
                 else:

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -294,7 +294,13 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         return list(devices.values())
 
     def get_device_state(self, entity_id: str) -> dict:
-        return self.client.get_state(entity_id, attribute="")
+        message = {'type': 'get_states'}
+        states = self._loop.run_until_complete(self.client.send_command(message))
+        if states != self.client.states:
+            LOG.warning(f"client states outdated!")
+        for state in states:
+            if state['entity_id'] == entity_id:
+                return state
 
     def set_device_state(self, entity_id: str, state: str, attributes: Optional[dict] = None):
         self.client.set_state(entity_id, state, attributes)

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import abstractmethod
 from typing import Optional, List
 
@@ -252,8 +253,9 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         super().__init__(host, api_key)
         import asyncio
         from hass_client.client import HomeAssistantClient
-
-        self.client: HomeAssistantClient = asyncio.run(self.start_client())
+        self._loop = asyncio.get_event_loop()
+        self.client: HomeAssistantClient = self._loop.run_until_complete(
+            self.start_client())
 
     async def start_client(self):
         from hass_client.client import HomeAssistantClient
@@ -304,15 +306,18 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
 
     def turn_on(self, device_id, device_type):
         LOG.debug(f"Turn on {device_id}")
-        self.client.call_service(device_type, 'turn_on',
-                                 {'entity_id': device_id})
+        self._loop.run_until_complete(
+            self.client.call_service(device_type, 'turn_on',
+                                     {'entity_id': device_id}))
 
     def turn_off(self, device_id, device_type):
         LOG.debug(f"Turn off {device_id}")
-        self.client.call_service(device_type, 'turn_off',
-                                 {'entity_id': device_id})
+        self._loop.run_until_complete(
+            self.client.call_service(device_type, 'turn_off',
+                                     {'entity_id': device_id}))
 
     def call_function(self, device_id, device_type, function, arguments=None):
         arguments = arguments or dict()
         arguments['entity_id'] = device_id
-        self.client.call_service(device_type, function, arguments)
+        self._loop.run_until_complete(
+            self.client.call_service(device_type, function, arguments))

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -251,6 +251,9 @@ class HomeAssistantRESTConnector(HomeAssistantConnector):
 class HomeAssistantWSConnector(HomeAssistantConnector):
     def __init__(self, host, api_key):
         super().__init__(host, api_key)
+        if self.host.startswith('http'):
+            self.host.replace('http', 'ws', 1)
+
         import asyncio
         from hass_client.client import HomeAssistantClient
         self._loop = asyncio.get_event_loop()

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -272,8 +272,8 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         self._device_entry_compat(devices)
         return list(devices.values())
 
-    def get_device_state(self, entity_id: str):
-        return self.client.get_state(entity_id)
+    def get_device_state(self, entity_id: str) -> dict:
+        return self.client.get_state(entity_id, attribute="")
 
     def set_device_state(self, entity_id: str, state: str, attributes: Optional[dict] = None):
         self.client.set_state(entity_id, state, attributes)

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -303,10 +303,14 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         return [d for d in devices if d['attributes'].get(attribute) not in value]
 
     def turn_on(self, device_id, device_type):
-        self.client.set_state(device_id, 'on')
+        LOG.debug(f"Turn on {device_id}")
+        self.client.call_service(device_type, 'turn_on',
+                                 {'entity_id': device_id})
 
     def turn_off(self, device_id, device_type):
-        self.client.set_state(device_id, 'off')
+        LOG.debug(f"Turn off {device_id}")
+        self.client.call_service(device_type, 'turn_off',
+                                 {'entity_id': device_id})
 
     def call_function(self, device_id, device_type, function, arguments=None):
         arguments = arguments or dict()

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -1,4 +1,3 @@
-import asyncio
 from abc import abstractmethod
 from typing import Optional, List
 
@@ -256,7 +255,10 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
 
         import asyncio
         from hass_client.client import HomeAssistantClient
-        self._loop = asyncio.get_event_loop()
+        try:
+            self._loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
         self.client: HomeAssistantClient = self._loop.run_until_complete(
             self.start_client())
 

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -258,7 +258,8 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         try:
             self._loop = asyncio.get_event_loop()
         except RuntimeError:
-            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(asyncio.new_event_loop())
+            self._loop = asyncio.get_event_loop()
         self.client: HomeAssistantClient = self._loop.run_until_complete(
             self.start_client())
 

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -4,6 +4,9 @@ from typing import Optional, List
 import requests
 import json
 import sys
+import asyncio
+
+from hass_client.client import HomeAssistantClient
 from ovos_utils.log import LOG
 
 
@@ -252,16 +255,12 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         super().__init__(host, api_key)
         if self.host.startswith('http'):
             self.host.replace('http', 'ws', 1)
-
-        import asyncio
-        from hass_client.client import HomeAssistantClient
         try:
             self._loop = asyncio.get_event_loop()
         except RuntimeError:
             asyncio.set_event_loop(asyncio.new_event_loop())
             self._loop = asyncio.get_event_loop()
-        self._client: HomeAssistantClient = HomeAssistantClient(self.host,
-                                                                self.api_key)
+        self._client: HomeAssistantClient = None
         self._loop.run_until_complete(self.start_client())
 
     @property
@@ -272,6 +271,8 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
         return self._client
 
     async def start_client(self):
+        self._client = self._client or HomeAssistantClient(self.host,
+                                                           self.api_key)
         await self._client.connect()
 
     @staticmethod

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -264,8 +264,16 @@ class HomeAssistantWSConnector(HomeAssistantConnector):
 
     @staticmethod
     def _device_entry_compat(devices: dict):
+        disabled_devices = list()
         for idx, dev in devices.items():
-            devices[idx].setdefault('type', dev['entity_id'].split('.', 1)[0])
+            if dev.get('disabled_by'):
+                LOG.debug(f'Ignoring {dev.get("entity_id")} disabled by '
+                          f'{dev.get("disabled_by")}')
+                disabled_devices.append(idx)
+            else:
+                devices[idx].setdefault('type', dev['entity_id'].split('.', 1)[0])
+        for idx in disabled_devices:
+            devices.pop(idx)
 
     def get_all_devices(self) -> list:
         devices = self.client.entity_registry

--- a/ovos_PHAL_plugin_homeassistant/logic/connector.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/connector.py
@@ -1,11 +1,15 @@
+from abc import abstractmethod
+from typing import Optional, List
+
 import requests
 import json
 import sys
 from ovos_utils.log import LOG
 
+
 class HomeAssistantConnector:
     def __init__(self, host, api_key):
-        """ Constructor 
+        """ Constructor
 
         Args:
             host (str): The host of the home assistant instance.
@@ -13,8 +17,105 @@ class HomeAssistantConnector:
         """
         self.host = host
         self.api_key = api_key
+
+    @abstractmethod
+    def get_all_devices(self) -> List[dict]:
+        """
+        Get a list of all devices.
+        """
+
+    @abstractmethod
+    def get_device_state(self, entity_id: str):
+        """
+        Get the state of a device.
+        Args:
+            entity_id (str): HomeAssistant Device ID
+        """
+
+    @abstractmethod
+    def set_device_state(self, entity_id: str, state: str,
+                         attributes: Optional[dict] = None):
+        """ Set the state of a device.
+
+        Args:
+            entity_id (str): The id of the device.
+            state (str): The state to set.
+            attributes (dict): The attributes to set.
+        """
+
+    @abstractmethod
+    def get_all_devices_with_type(self, device_type):
+        """ Get all devices with a specific type.
+
+        Args:
+            device_type (str): The type of the device.
+        """
+
+    @abstractmethod
+    def get_all_devices_with_type_and_attribute(self, device_type, attribute, value):
+        """ Get all devices with a specific type and attribute.
+
+        Args:
+            device_type (str): The type of the device.
+            attribute (str): The attribute to check.
+            value (str): The value of the attribute.
+        """
+
+    @abstractmethod
+    def get_all_devices_with_type_and_attribute_in(self, device_type, attribute, value):
+        """ Get all devices with a specific type and attribute.
+
+        Args:
+            device_type (str): The type of the device.
+            attribute (str): The attribute to check.
+            value (str): The value of the attribute.
+        """
+
+    @abstractmethod
+    def get_all_devices_with_type_and_attribute_not_in(self, device_type, attribute, value):
+        """ Get all devices with a specific type and attribute.
+
+        Args:
+            device_type (str): The type of the device.
+            attribute (str): The attribute to check.
+            value (str): The value of the attribute.
+        """
+
+    @abstractmethod
+    def turn_on(self, device_id, device_type):
+        """ Turn on a device.
+
+        Args:
+            device_id (str): The id of the device.
+            device_type (str): The type of the device.
+        """
+
+    @abstractmethod
+    def turn_off(self, device_id, device_type):
+        """ Turn off a device.
+
+        Args:
+            device_id (str): The id of the device.
+            device_type (str): The type of the device.
+        """
+
+    @abstractmethod
+    def call_function(self, device_id, device_type, function, arguments=None):
+        """ Call a function on a device.
+
+        Args:
+            device_id (str): The id of the device.
+            device_type (str): The type of the device.
+            function (str): The function to call.
+            arguments (dict): The arguments to pass to the function.
+        """
+
+
+class HomeAssistantRESTConnector(HomeAssistantConnector):
+    def __init__(self, host, api_key):
+        super().__init__(host, api_key)
         self.headers = {'Authorization': 'Bearer ' +
-                        api_key, 'content-type': 'application/json'}
+                        self.api_key, 'content-type': 'application/json'}
 
     def get_all_devices(self):
         """ Get all devices from home assistant. """
@@ -26,9 +127,9 @@ class HomeAssistantConnector:
             print("Error connecting to home assistant")
             sys.exit(1)
 
-    def get_device_state(self, device_id):
+    def get_device_state(self, entity_id):
         """ Get the state of a device. """
-        url = self.host + ":8123/api/states/" + device_id
+        url = self.host + ":8123/api/states/" + entity_id
         response = requests.get(url, headers=self.headers)
         if response.status_code == 200:
             return json.loads(response.text)
@@ -36,15 +137,15 @@ class HomeAssistantConnector:
             print("Error connecting to home assistant")
             sys.exit(1)
 
-    def set_device_state(self, device_id, state, attributes=None):
+    def set_device_state(self, entity_id, state, attributes=None):
         """ Set the state of a device. 
 
         Args:
-            device_id (str): The id of the device.
+            entity_id (str): The id of the device.
             state (str): The state to set.
             attributes (dict): The attributes to set. 
         """
-        url = self.host + ":8123/api/states/" + device_id
+        url = self.host + ":8123/api/states/" + entity_id
         payload = {'state': state, 'attributes': attributes}
         response = requests.post(
             url, data=json.dumps(payload), headers=self.headers)
@@ -144,3 +245,62 @@ class HomeAssistantConnector:
         
         if response.status_code == 200:
             return json.loads(response.text)
+
+
+class HomeAssistantWSConnector(HomeAssistantConnector):
+    def __init__(self, host, api_key):
+        super().__init__(host, api_key)
+        import asyncio
+        from hass_client.client import HomeAssistantClient
+
+        self.client: HomeAssistantClient = asyncio.run(self.start_client())
+
+    async def start_client(self):
+        from hass_client.client import HomeAssistantClient
+
+        client = HomeAssistantClient(self.host, self.api_key)
+        await client.connect()
+        return client
+
+    @staticmethod
+    def _device_entry_compat(devices: dict):
+        for idx, dev in devices.items():
+            devices[idx].setdefault('type', dev['entity_id'].split('.', 1)[0])
+
+    def get_all_devices(self) -> list:
+        devices = self.client.entity_registry
+        self._device_entry_compat(devices)
+        return list(devices.values())
+
+    def get_device_state(self, entity_id: str):
+        return self.client.get_state(entity_id)
+
+    def set_device_state(self, entity_id: str, state: str, attributes: Optional[dict] = None):
+        self.client.set_state(entity_id, state, attributes)
+
+    def get_all_devices_with_type(self, device_type):
+        devices = self.get_all_devices()
+        return [d for d in devices if d.get('type') == device_type]
+
+    def get_all_devices_with_type_and_attribute(self, device_type, attribute, value):
+        devices = self.get_all_devices()
+        return [d for d in devices if d['attributes'].get(attribute) == value]
+
+    def get_all_devices_with_type_and_attribute_in(self, device_type, attribute, value):
+        devices = self.get_all_devices()
+        return [d for d in devices if d['attributes'].get(attribute) in value]
+
+    def get_all_devices_with_type_and_attribute_not_in(self, device_type, attribute, value):
+        devices = self.get_all_devices()
+        return [d for d in devices if d['attributes'].get(attribute) not in value]
+
+    def turn_on(self, device_id, device_type):
+        self.client.set_state(device_id, 'on')
+
+    def turn_off(self, device_id, device_type):
+        self.client.set_state(device_id, 'off')
+
+    def call_function(self, device_id, device_type, function, arguments=None):
+        arguments = arguments or dict()
+        arguments['entity_id'] = device_id
+        self.client.call_service(device_type, function, arguments)

--- a/ovos_PHAL_plugin_homeassistant/logic/device.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/device.py
@@ -154,8 +154,11 @@ class HomeAssistantDevice:
         """ Poll the device. """
         full_state_json = self.connector.get_device_state(self.device_id)
         LOG.debug(full_state_json)
-        self.device_state = full_state_json.get("state", "unknown")
-        self.device_attributes = full_state_json.get("attributes", {})
+        if full_state_json == 'unavailable':
+            LOG.warning(f"State unavailable for device: {self.device_id}")
+        else:
+            self.device_state = full_state_json.get("state", "unknown")
+            self.device_attributes = full_state_json.get("attributes", {})
 
     def get_device_display_model(self):
         """ Get the display model of the device. """

--- a/ovos_PHAL_plugin_homeassistant/logic/device.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/device.py
@@ -2,6 +2,8 @@ import requests
 import json
 from ovos_utils.log import LOG
 
+from ovos_PHAL_plugin_homeassistant.logic.connector import HomeAssistantRESTConnector
+
 
 class HomeAssistantDevice:
     def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
@@ -151,6 +153,7 @@ class HomeAssistantDevice:
     def poll(self):
         """ Poll the device. """
         full_state_json = self.connector.get_device_state(self.device_id)
+        LOG.debug(full_state_json)
         self.device_state = full_state_json.get("state", "unknown")
         self.device_attributes = full_state_json.get("attributes", {})
 

--- a/ovos_PHAL_plugin_homeassistant/logic/device.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/device.py
@@ -6,7 +6,7 @@ from ovos_PHAL_plugin_homeassistant.logic.connector import HomeAssistantRESTConn
 
 
 class HomeAssistantDevice:
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes, device_area = None):
         """ Initialize the device.
 
         Args:
@@ -16,6 +16,7 @@ class HomeAssistantDevice:
             device_name (str): The name of the device.
             device_state (str): The state of the device.
             device_attributes (dict): The attributes of the device.
+            device_area (str): Name of area device is in (None if no area)
         """
         self.connector = connector
         self.device_id = device_id
@@ -23,6 +24,7 @@ class HomeAssistantDevice:
         self.device_name = device_name
         self.device_state = device_state
         self.device_attributes = device_attributes
+        self.device_area = device_area
         self.has_device_class = False
         self.device_class = None
         self.device_type = self.device_id.split(".")[0]
@@ -174,9 +176,11 @@ class HomeAssistantDevice:
 
 
 class HomeAssistantLight(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def get_brightness(self):
         """ Get the brightness of the light. """
@@ -280,15 +284,19 @@ class HomeAssistantLight(HomeAssistantDevice):
 
 
 class HomeAssistantSwitch(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
 
 class HomeAssistantSensor(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def get_device_class(self):
         """ Get the device class of the sensor. """
@@ -316,9 +324,11 @@ class HomeAssistantSensor(HomeAssistantDevice):
 
 
 class HomeAssistantBinarySensor(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def get_device_class(self):
         """ Get the device class of the binary sensor. """
@@ -326,9 +336,11 @@ class HomeAssistantBinarySensor(HomeAssistantDevice):
 
 
 class HomeAssistantCover(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def open(self):
         """ Open the cover. """
@@ -372,9 +384,11 @@ class HomeAssistantCover(HomeAssistantDevice):
 
 
 class HomeAssistantMediaPlayer(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def get_media_title(self):
         """ Get the media title of the media player. """
@@ -442,9 +456,11 @@ class HomeAssistantMediaPlayer(HomeAssistantDevice):
 
 
 class HomeAssistantClimate(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def set_temperature(self, temperature):
         """ Set the temperature of the climate device.
@@ -583,9 +599,11 @@ class HomeAssistantClimate(HomeAssistantDevice):
 
 
 class HomeAssistantVacuum(HomeAssistantDevice):
-    def __init__(self, connector, device_id, device_icon, device_name, device_state, device_attributes):
+    def __init__(self, connector, device_id, device_icon, device_name,
+                 device_state, device_attributes, device_area=None):
         super().__init__(connector, device_id, device_icon,
-                         device_name, device_state, device_attributes)
+                         device_name, device_state, device_attributes,
+                         device_area)
 
     def start(self):
         """ Start the vacuum. """

--- a/ovos_PHAL_plugin_homeassistant/logic/device.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/device.py
@@ -155,11 +155,12 @@ class HomeAssistantDevice:
     def poll(self):
         """ Poll the device. """
         full_state_json = self.connector.get_device_state(self.device_id)
-        LOG.debug(full_state_json)
+        # LOG.debug(full_state_json)
         if full_state_json == 'unavailable':
             LOG.warning(f"State unavailable for device: {self.device_id}")
         elif not isinstance(full_state_json, dict):
-            LOG.error(f'Expected dict state but got: {full_state_json}')
+            LOG.error(f'({self.device_name}) Expected dict state but got: '
+                      f'{full_state_json}')
         else:
             self.device_state = full_state_json.get("state", "unknown")
             self.device_attributes = full_state_json.get("attributes", {})

--- a/ovos_PHAL_plugin_homeassistant/logic/device.py
+++ b/ovos_PHAL_plugin_homeassistant/logic/device.py
@@ -158,6 +158,8 @@ class HomeAssistantDevice:
         LOG.debug(full_state_json)
         if full_state_json == 'unavailable':
             LOG.warning(f"State unavailable for device: {self.device_id}")
+        elif not isinstance(full_state_json, dict):
+            LOG.error(f'Expected dict state but got: {full_state_json}')
         else:
             self.device_state = full_state_json.get("state", "unknown")
             self.device_attributes = full_state_json.get("attributes", {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ovos-config~=0.0.5
 mycroft-messagebus-client
 youtube-search
 pytube
+hass-client~=0.1


### PR DESCRIPTION
Adds a WS API via the hass-client package that can be enabled via plugin settings. This only adds Websocket as a backend with the same functionality as REST, but there is more data present in devices that can be parsed, like areas