### PR TITLE
Refactor oauth flow

### DIFF
--- a/ovos_PHAL_plugin_homeassistant/__init__.py
+++ b/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -820,8 +820,8 @@ class HomeAssistantPlugin(PHALPlugin):
             }))
         if not resp:
             raise TimeoutError("No oauth registration response!")
-        if resp.data.get('error'):
-            raise RuntimeError(resp.data['error'])
+        if resp.data.get("error"):
+            raise RuntimeError(resp.data["error"])
 
     def start_oauth_flow(self, message):
         """
@@ -838,8 +838,8 @@ class HomeAssistantPlugin(PHALPlugin):
         if not resp:
             raise RuntimeError(f"No response from oauth plugin to message: "
                                f"{message.msg_type}: {message.data}")
-        if resp.data.get('error'):
-            raise RuntimeError(resp.data['error'])
+        if resp.data.get("error"):
+            raise RuntimeError(resp.data["error"])
         self.handle_qr_oauth_response(resp)
 
     def handle_qr_oauth_response(self, message):

--- a/ovos_PHAL_plugin_homeassistant/__init__.py
+++ b/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -808,15 +808,20 @@ class HomeAssistantPlugin(PHALPlugin):
         auth_endpoint = f"{host}/auth/authorize"
         token_endpoint = f"{host}/auth/token"
         LOG.debug(f"Registering oauth client: {self.oauth_client_id}")
-        self.bus.emit(Message("oauth.register", {
-            "client_id": self.oauth_client_id,
-            "skill_id": "ovos-PHAL-plugin-homeassistant",
-            "app_id": "homeassistant-phal-plugin",
-            "auth_endpoint": auth_endpoint,
-            "token_endpoint": token_endpoint,
-            "shell_integration": False,
-            "refresh_endpoint": "",
-        }))
+        resp = self.bus.wait_for_response(Message(
+            "oauth.register", {
+                "client_id": self.oauth_client_id,
+                "skill_id": "ovos-PHAL-plugin-homeassistant",
+                "app_id": "homeassistant-phal-plugin",
+                "auth_endpoint": auth_endpoint,
+                "token_endpoint": token_endpoint,
+                "shell_integration": False,
+                "refresh_endpoint": "",
+            }))
+        if not resp:
+            raise TimeoutError("No oauth registration response!")
+        if resp.data.get('error'):
+            raise RuntimeError(resp.data['error'])
 
     def start_oauth_flow(self, message):
         """

--- a/ovos_PHAL_plugin_homeassistant/__init__.py
+++ b/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -787,7 +787,7 @@ class HomeAssistantPlugin(PHALPlugin):
             Args:
                 message (Message): The message object
         """
-        instance = message.data.get("instance").lower()
+        instance = message.data.get("instance", "").lower()
         if instance:
             LOG.info(f"Starting oauth for: {instance}")
             self.temporary_instance = instance
@@ -819,7 +819,9 @@ class HomeAssistantPlugin(PHALPlugin):
                 "refresh_endpoint": "",
             }))
         if not resp:
-            raise TimeoutError("No oauth registration response!")
+            raise TimeoutError(f"No oauth registration response for endpoint: "
+                               f"{auth_endpoint}. "
+                               f"client_id={self.oauth_client_id}")
         if resp.data.get("error"):
             raise RuntimeError(resp.data["error"])
 

--- a/ovos_PHAL_plugin_homeassistant/__init__.py
+++ b/ovos_PHAL_plugin_homeassistant/__init__.py
@@ -757,8 +757,9 @@ class HomeAssistantPlugin(PHALPlugin):
         @param message: Message associated with oauth start request
         @return:
         """
-        resp = self.bus.wait_for_response(message.forward(
-            "oauth.get.app.host.info"), "oauth.app.host.info.response", 10)
+        message = message.forward("oauth.get.app.host.info")
+        resp = self.bus.wait_for_response(message,
+                                          "oauth.app.host.info.response")
         if not resp:
             raise RuntimeError(f"No response from oauth plugin to message: "
                                f"{message.msg_type}: {message.data}")
@@ -825,13 +826,15 @@ class HomeAssistantPlugin(PHALPlugin):
         """
         app_id = "homeassistant-phal-plugin"
         skill_id = "ovos-PHAL-plugin-homeassistant"
-        resp = self.bus.wait_for_response(
-            message.forward("oauth.generate.qr.request",
-                            {"app_id": app_id, "skill_id": skill_id}),
-            "oauth.generate.qr.response")
+        message = message.forward("oauth.generate.qr.request",
+                                  {"app_id": app_id, "skill_id": skill_id})
+        resp = self.bus.wait_for_response(message,
+                                          "oauth.generate.qr.response")
         if not resp:
             raise RuntimeError(f"No response from oauth plugin to message: "
                                f"{message.msg_type}: {message.data}")
+        if resp.data.get('error'):
+            raise RuntimeError(resp.data['error'])
         self.handle_qr_oauth_response(resp)
 
     def handle_qr_oauth_response(self, message):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ovos-config~=0.0.5
 youtube-search~=2.1
 pytube~=12.1
 websockets~=10.4
-ovos-PHAL-plugin-oauth~=0.0.1
+ovos-PHAL-plugin-oauth~=0.0.1,>=0.0.3a2
 nested-lookup~=0.2
 ovos-bus-client~=0.0.3
 webcolors~=1.13


### PR DESCRIPTION
Removes redundant `self.bus` definition
Refactor oauth message handling to use `get_response` instead of registering handlers
Remove redundant `data=None` from `message.forward` calls causing editor warnings
Add annotations to methods