### PR TITLE
chore: update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager~=0.0.23
-ovos-utils~=0.0.27
+ovos-utils~=0.0.27,<1.0.0
 ovos-config~=0.0.5
 youtube-search~=2.1
 pytube~=12.1


### PR DESCRIPTION
`ovos-phal-plugin-homeassistant 0.0.4a4 requires ovos-utils~=0.0.27, but you have ovos-utils 0.1.0a8 which is incompatible.`