### PR TITLE
fix(requirements): compat with utils and workshop 0.1.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 ovos-plugin-manager~=0.0.23
-ovos-utils~=0.0.27
+ovos-utils<0.2.0,>=0.0.27
 ovos-config~=0.0.5
 youtube-search~=2.1
 pytube~=12.1
 websockets~=10.4
 ovos-PHAL-plugin-oauth~=0.0.1,>=0.0.3a2
 nested-lookup~=0.2
-ovos-bus-client~=0.0.8
+ovos-bus-client<0.2.0,>=0.0.8
 webcolors~=1.13


### PR DESCRIPTION
Allows compat with OVOS systems running workshop 0.1.0+ or utils 0.1.0+