### PR TITLE
fix:semver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-ovos-plugin-manager~=0.0.23
-ovos-utils<0.2.0,>=0.0.27
-ovos-config~=0.0.5
+ovos-plugin-manager<=0.0.23,<1.0.0
+ovos-utils>=0.0.27,<1.0.0
+ovos-config>=0.0.5,<1.0.0
+ovos-PHAL-plugin-oauth>=0.0.3,<1.0.0
+ovos-bus-client>=0.0.8,<1.0.0
 youtube-search~=2.1
 pytube~=12.1
 websockets>=0.54.0,<13.0
-ovos-PHAL-plugin-oauth~=0.0.1,>=0.0.3a2
 nested-lookup~=0.2
-ovos-bus-client<0.2.0,>=0.0.8
 webcolors~=1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ovos-plugin-manager<=0.0.23,<1.0.0
+ovos-plugin-manager>=0.0.23,<1.0.0
 ovos-utils>=0.0.27,<1.0.0
 ovos-config>=0.0.5,<1.0.0
 ovos-PHAL-plugin-oauth>=0.0.3,<1.0.0


### PR DESCRIPTION
allow plugin to work with latest stable releases of everything

now that we follow semver pinned max versions based on next expected breaking change